### PR TITLE
feat(docs): Integrate and serve live dbt documentation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,3 +29,13 @@ RUN mkdir -p /app/pipelines/data_lake/bronze && \
     mkdir -p /app/pipelines/data_lake/analytics
 EXPOSE 8501
 CMD ["streamlit", "run", "1_Manual_CSV_Upload.py", "--server.address=0.0.0.0"]
+
+
+# ===== dbt Docs Stage =====
+# This stage generates and serves the dbt documentation website.
+FROM base as dbt_docs
+WORKDIR /app/analytics
+
+# Serve the generated documentation on port 8081
+EXPOSE 8081
+CMD ["python", "-m", "http.server", "8081", "--directory", "./target"]

--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@ This command will build the necessary Docker images, start all services, and mak
 Once the system is running, you can access the different components at the following URLs:
 
 *   **Streamlit Analyst UI:** [http://localhost:8501](http://localhost:8501)
+*   **dbt Documentation:** [http://localhost:8081](http://localhost:8081)
 *   **Mock Flinks API (for exploration):** [http://localhost:5000](http://localhost:5000)
 
 ### Workflow 1: Manual Analysis for a Single Customer

--- a/analytics/analytics_development.ipynb
+++ b/analytics/analytics_development.ipynb
@@ -10,7 +10,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 122,
+   "execution_count": 166,
    "id": "c65b96ab-9dd7-4ad4-a6a9-a2ed61cb5e43",
    "metadata": {},
    "outputs": [
@@ -54,7 +54,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 123,
+   "execution_count": 167,
    "id": "24f9d3c1-8d2c-466f-8c06-7f3e478ee8d2",
    "metadata": {},
    "outputs": [
@@ -124,7 +124,7 @@
        "4                          statements"
       ]
      },
-     "execution_count": 123,
+     "execution_count": 167,
      "metadata": {},
      "output_type": "execute_result"
     }

--- a/app_utils.py
+++ b/app_utils.py
@@ -67,6 +67,16 @@ def run_analysis_pipeline(source_df: pd.DataFrame):
             if dbt_process.stdout:
                 logger.info(f"{log_prefix} dbt stdout:\n{dbt_process.stdout}")
 
+            logger.info(f"{log_prefix} Generating dbt documentation...")
+            dbt_docs_process = subprocess.run(
+                ["dbt", "docs", "generate"],
+                cwd="analytics",
+                check=True,
+                capture_output=True,
+                text=True
+            )
+            logger.info(f"{log_prefix} dbt docs generation completed successfully.")
+
             # --- Step 3: Generating Final Report ---
             logger.info(f"{log_prefix} Starting Step 3/3: Reading final results from dbt database at {DBT_DB_PATH}...")
             with duckdb.connect(DBT_DB_PATH, read_only=True) as con:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,3 +38,20 @@ services:
       - PWD=/app
       # This variable tells the application where the root directory is inside the container.
       - DATA_LAKE_ROOT=/app
+
+  dbt_docs:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: dbt_docs
+    ports:
+      - "8081:8081"
+    volumes:
+      # Mount the analytics project and data lake so docs can be generated
+      # against the current state of the data.
+      - ./analytics:/app/analytics
+      - ./data_lake:/app/data_lake
+    depends_on:
+      - api
+    environment:
+      - DATA_LAKE_ROOT=/app


### PR DESCRIPTION
## Description

This pull request enhances the project's professional quality and developer experience by integrating **live `dbt` documentation**.

A new service has been added that automatically generates and serves the dbt docs website, providing any user with an interactive data dictionary, model dependency graph, and full source code of the analytics project. This is a critical feature for maintainability, transparency, and collaboration.

## Key Changes

- **New `dbt_docs` Service:** A third service is now orchestrated by `docker-compose`, available at **[http://localhost:8081](http://localhost:8081)**.
- **Robust Generation Logic:** The documentation is now generated as part of the main application pipeline (`app_utils.py`) after a successful `dbt run`. This ensures the docs are always up-to-date and generated in a runtime environment with all necessary data volumes, fixing previous build-time errors.
- **Lightweight Server:** The `dbt_docs` service itself is now just a simple, lightweight Python web server for the static files generated by the main app, making it more efficient.
- **Updated README:** The main `README.md` has been updated with a link to the new documentation service for easy access.

## How to Test

1.  Run `make start`.
2.  Once all services are running, navigate to **[http://localhost:8081](http://localhost:8081)** in your browser.
3.  You should see the fully interactive dbt documentation website.
4.  Run a new analysis through the Streamlit UI to confirm that the documentation is correctly regenerated on each run.