### PR TITLE
feat(taktile): Display detailed Taktile results and improve UI flow

### DIFF
--- a/app/1_Manual_CSV_Upload.py
+++ b/app/1_Manual_CSV_Upload.py
@@ -3,7 +3,7 @@ import pandas as pd
 import sys
 import os
 import logging
-from app_utils import run_analysis_pipeline, display_taktile_interface
+from app_utils import run_analysis_pipeline, display_taktile_interface, display_reset_button
 
 # --- Logging Configuration ---
 logging.basicConfig(
@@ -32,7 +32,7 @@ st.write(
     """
 )
 
-st.header("Track A: Manual CSV Upload")
+st.header("Manual CSV Upload")
 st.write("This is the standard workflow for an analyst to manually upload and process statements.")
 
 uploaded_files = st.file_uploader(
@@ -40,6 +40,9 @@ uploaded_files = st.file_uploader(
     type="csv",
     accept_multiple_files=True
 )
+
+
+display_reset_button(st, logger)
 
 if st.button("Run Analysis on Uploaded CSVs"):
     if uploaded_files:
@@ -50,4 +53,4 @@ if st.button("Run Analysis on Uploaded CSVs"):
         logger.warning("CSV analysis button clicked but no files were uploaded.")
 
 # --- Persisted Metrics Review & Taktile Dispatch ---
-display_taktile_interface(st, logger)
+display_taktile_interface(st, logger, key_prefix="manual")

--- a/app/pages/2_Automated_API_Run.py
+++ b/app/pages/2_Automated_API_Run.py
@@ -2,13 +2,14 @@ import streamlit as st
 import pandas as pd
 import requests
 import logging
-from app_utils import run_analysis_pipeline, display_taktile_interface
+from app_utils import run_analysis_pipeline, display_taktile_interface, display_reset_button
 
 logger = logging.getLogger(__name__)
 
 st.set_page_config(layout="wide", page_title="Automated API Run")
 
 st.title("Automated API Ingestion")
+display_reset_button(st, logger)
 st.write("This simulates an automated workflow where data is pulled from a source API.")
 
 # Note: Ensure the mock API server is running.
@@ -44,4 +45,4 @@ if st.button("Ingest from Mock API and Run Analysis"):
         logger.warning("API analysis button clicked but no email was provided.")
 
 # --- Persisted Metrics Review & Taktile Dispatch ---
-display_taktile_interface(st, logger)
+display_taktile_interface(st, logger, key_prefix="automated")


### PR DESCRIPTION
### Description

This PR significantly enhances the user experience by transforming the Taktile API response into a detailed, human-readable report within the Streamlit interface.

Previously, the application would only display the raw JSON response from the Taktile decision engine. This update introduces a rich, formatted breakdown of the credit decision, including:
- Risk Tier Estimation
- Line Assignment & Credit Limit
- Highlighted Approval Amount
- Card's MCA and Capital MCA details
- A combined table of input features and output results, available for download.

### Key Changes
- **`app/app_utils.py`**:
    - Implemented a comprehensive display logic in `display_taktile_interface` to parse and render the Taktile decision.
    - Added a `display_reset_button` function to allow users to easily clear results and start a new analysis.
    - Improved session state management by clearing previous results before a new run and using page-specific keys.
- **`app/1_Manual_CSV_Upload.py` & `app/pages/2_Automated_API_Run.py`**:
    - Integrated the new "Start New Analysis" button for better UX.
    - Updated calls to `display_taktile_interface` with unique keys to prevent state conflicts between pages.

### How to Test
1. Run the Streamlit application.
2. Go to either the "Manual CSV Upload" or "Automated API Run" page.
3. Process a customer's data to the point where the "Send to Taktile" button appears.
4. Click the button.
5. **Verify** that instead of a JSON dump, a detailed report with multiple tables and a highlighted approval amount is displayed.
6. **Verify** that the "Download Results as CSV" button works and contains the combined data.
7. Click the "Start New Analysis" button.
8. **Verify** that all results from the previous run are cleared from the UI.