### PR TITLE
feat(testing): Add Dockerized test environment

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,3 +53,18 @@ WORKDIR /app
 # Expose the Jupyter port
 EXPOSE 8888
 CMD ["jupyter", "lab", "--ip=0.0.0.0", "--port=8888", "--no-browser", "--allow-root", "--NotebookApp.token=''"]
+
+
+# ===== Test Stage =====
+# This stage is specifically for running the test suite.
+FROM base as test
+WORKDIR /app
+
+# Copy all application and test code
+COPY ./api_mock ./api_mock
+COPY ./app ./app
+COPY ./pipelines ./pipelines
+COPY ./tests ./tests
+
+# Default command is to run pytest. This will be overridden in docker-compose.
+CMD ["pytest", "-v"]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,10 @@
-.PHONY: stop start
+.PHONY: stop start test
 
 stop:
 	docker-compose down
 
 start: stop
 	docker-compose up --build
+
+test:
+	docker-compose run --build --rm test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,3 +73,12 @@ services:
       - ./docs:/app/docs
     depends_on:
       - api
+
+  test:
+    build:
+      context: .
+      dockerfile: Dockerfile
+      target: test
+    depends_on:
+      - api
+    command: ["pytest", "-v", "--cov=api_mock", "--cov=app", "--cov=pipelines"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 Flask
 pytest
+pytest-cov
 pandas
 pyarrow
 requests
@@ -10,3 +11,4 @@ deltalake
 streamlit
 duckdb
 jupyterlab
+pytest-mock


### PR DESCRIPTION
# Feat: Add Dockerized Test Environment

### Description

This PR introduces a containerized testing environment using Docker and Docker Compose to ensure consistency and simplify the testing process for all developers.

By abstracting the entire setup into a single `make test` command, we eliminate the "it works on my machine" problem and provide a reproducible way to run the entire test suite, including service dependencies like the mock API.

### Key Changes

-   **`Dockerfile`**:
    -   Added a new multi-stage build target named `test`. This stage builds on the `base` image and copies all necessary application and test code into a clean environment.

-   **`docker-compose.yml`**:
    -   Defined a new service named `test` that uses the `test` build target.
    -   Configured the service to depend on the `api` service, ensuring the mock API is running before tests begin.
    -   The `command` is set to run `pytest` with coverage for all relevant application directories (`api_mock`, `app`, `pipelines`).

-   **`Makefile`**:
    -   Added a new `test` target that runs `docker-compose run --build --rm test`.
    -   The `--build` flag ensures that any changes to `Dockerfile` or `requirements.txt` are always incorporated.
    -   The `--rm` flag ensures the test container is removed after the run, keeping the local environment clean.

-   **`requirements.txt`**:
    -   Added `pytest-cov` to the list of dependencies to ensure coverage reporting tools are available within the Docker container.

### How to Use

To run the entire test suite in a consistent, isolated environment, simply run the following command from the project root:
```bash
make test
```
```